### PR TITLE
[Feature] Lenient property validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.7.1
+
+* Fixed: incorrect URL representation for Decimal properties
+
 ## 0.7.0
 
 Major rewrite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 0.7.1
 
-* Fixed: incorrect URL representation for Decimal properties
+* [New Feature] Optional lenient property validation
+* [Fixed] Incorrect URL representation for Decimal properties
 
 ## 0.7.0
 

--- a/README.md
+++ b/README.md
@@ -239,6 +239,21 @@ or, you can get a hold of the property class instance using
 
 This will parse and instantiate the property if it hasn't done so yet.
 
+##### Lenient Property Validation
+
+By default, we use strict property validation, meaning that any property validation errors in the data will raise an exception.
+However, you may encounter OData implementations in the wild that break the specs in strange and surprising ways (shocking, I know!).
+
+Since it's often better to get *some* data instead of nothing at all, you can optionally make the property validation lenient.
+Simply add `strict: false` to the service constructor options.
+In this mode, any property validation error will log a warning instead of raising an exception. The corresponding property value will be `nil` (even if the property is declared as not allowing NULL values).
+
+```ruby
+  service = OData4::Service.open('http://services.odata.org/V4/OData/OData.svc', strict: false)
+  # -- alternatively, for an existing service instance --
+  service.options[:strict] = false
+```
+
 ### Queries
 
 `OData4::Query` instances form the base for finding specific entities within an `OData4::EntitySet`.
@@ -265,6 +280,17 @@ You should refer to the published RubyDocs for full details on the various capab
 
  * [OData4::Query](http://rubydoc.info/github/wrstudios/odata4/master/OData4/Query)
  * [OData4::Query::Criteria](http://rubydoc.info/github/wrstudios/odata4/master/OData4/Query/Criteria)
+
+## To Do
+
+[x] ~Lenient property validation~
+[ ] Write support (create/update/delete)
+[ ] Support for invoking [Operations][odata-ops] (Functions/Actions)
+[ ] [Property facets][odata-facets]
+[ ] Annotations
+
+[odata-facets]: http://docs.oasis-open.org/odata/odata/v4.0/errata03/os/complete/part3-csdl/odata-v4.0-errata03-os-part3-csdl-complete.html#_Toc453752528
+[odata-ops]: http://docs.oasis-open.org/odata/odata/v4.0/errata03/os/complete/part1-protocol/odata-v4.0-errata03-os-part1-protocol-complete.html#_Toc453752307
 
 ## Contributing
 

--- a/lib/odata4/entity.rb
+++ b/lib/odata4/entity.rb
@@ -237,7 +237,7 @@ module OData4
       if klass.nil?
         raise RuntimeError, "Unknown property type: #{value_type}"
       else
-        klass.from_xml(value_xml)
+        klass.from_xml(value_xml, service: service)
       end
     end
 

--- a/lib/odata4/enum_type/property.rb
+++ b/lib/odata4/enum_type/property.rb
@@ -46,7 +46,7 @@ module OData4
           elsif members.values.include?(value)
             value
           else
-            raise ArgumentError, "Property '#{name}': Value must be one of #{members.to_a}, but was: '#{value}'" if strict?
+            validation_error "Value must be one of #{members.to_a}, but was: '#{value}'"
           end
         end.compact
       end

--- a/lib/odata4/properties/binary.rb
+++ b/lib/odata4/properties/binary.rb
@@ -42,7 +42,7 @@ module OData4
 
       def validate(value)
         unless [0,1,'0','1',true,false].include?(value)
-          raise ArgumentError, 'Value is outside accepted range: 0 or 1'
+          validation_error 'Value is outside accepted range: 0 or 1'
         end
       end
     end

--- a/lib/odata4/properties/boolean.rb
+++ b/lib/odata4/properties/boolean.rb
@@ -29,7 +29,7 @@ module OData4
       def validate(value)
         return if value.nil? && allows_nil?
         unless [0,1,'0','1','true','false',true,false].include?(value)
-          raise ArgumentError, 'Value is outside accepted range: true or false'
+          validation_error 'Value is outside accepted range: true or false'
         end
       end
     end

--- a/lib/odata4/properties/date_time.rb
+++ b/lib/odata4/properties/date_time.rb
@@ -65,7 +65,7 @@ module OData4
           return if value.is_a?(date_class)
           date_class.parse(value)
         rescue
-          raise ArgumentError, "Value '#{value}' is not a date time format that can be parsed"
+          validation_error "Value '#{value}' is not a date time format that can be parsed"
         end
       end
 

--- a/lib/odata4/properties/decimal.rb
+++ b/lib/odata4/properties/decimal.rb
@@ -27,7 +27,7 @@ module OData4
       # Value to be used in URLs.
       # @return [String]
       def url_value
-        "#{value.to_f}M"
+        "#{value.to_f}"
       end
 
       private

--- a/lib/odata4/properties/decimal.rb
+++ b/lib/odata4/properties/decimal.rb
@@ -34,7 +34,7 @@ module OData4
 
       def validate(value)
         if value > max_value || value < min_value || value.precs.first > 29
-          raise ArgumentError, "Value is outside accepted range: #{min_value} to #{max_value}, or has more than 29 significant digits"
+          validation_error "Value is outside accepted range: #{min_value} to #{max_value}, or has more than 29 significant digits"
         end
       end
 

--- a/lib/odata4/properties/number.rb
+++ b/lib/odata4/properties/number.rb
@@ -6,7 +6,7 @@ module OData4
 
       def validate(value)
         if value > max_value || value < min_value
-          raise ::ArgumentError, "Value is outside accepted range: #{min_value} to #{max_value}"
+          validation_error "Value is outside accepted range: #{min_value} to #{max_value}"
         end
       end
     end

--- a/lib/odata4/properties/string.rb
+++ b/lib/odata4/properties/string.rb
@@ -56,7 +56,7 @@ module OData4
 
       def validate(new_value)
         if new_value.nil? && !allows_nil?
-          raise ArgumentError, 'This property does not allow for nil values to be set'
+          validation_error 'This property does not allow for nil values to be set'
         end
       end
 

--- a/lib/odata4/properties/time.rb
+++ b/lib/odata4/properties/time.rb
@@ -28,7 +28,7 @@ module OData4
 
       def validate(value)
         unless value.is_a?(::Time)
-          raise ArgumentError, 'Value is not a time object'
+          validation_error 'Value is not a time object'
         end
       end
 

--- a/lib/odata4/property.rb
+++ b/lib/odata4/property.rb
@@ -8,6 +8,8 @@ module OData4
     attr_reader :name
     # The property's value
     attr_accessor :value
+    # The property's options
+    attr_reader :options
 
     # Default intialization for a property with a name, value and options.
     # @param name [to_s]
@@ -107,9 +109,7 @@ module OData4
       new(property_xml.name, content, options)
     end
 
-    private
-
-    attr_reader :options
+    protected
 
     def default_options
       {

--- a/lib/odata4/service.rb
+++ b/lib/odata4/service.rb
@@ -262,7 +262,8 @@ module OData4
         typhoeus: {
           headers: { 'OData4-Version' => '4.0' },
           timeout: HTTP_TIMEOUT
-        }
+        },
+        strict: true # strict property validation
       }
     end
 
@@ -317,7 +318,7 @@ module OData4
     def process_property_from_xml(property_xml)
       property_name = property_xml.attributes['Name'].value
       value_type = property_xml.attributes['Type'].value
-      property_options = {}
+      property_options = { service: self }
 
       klass = ::OData4::PropertyRegistry[value_type]
 

--- a/spec/odata4/enum_type_spec.rb
+++ b/spec/odata4/enum_type_spec.rb
@@ -54,12 +54,10 @@ describe OData4::EnumType, vcr: {cassette_name: 'enum_type_specs'} do
       expect(subject.value).to eq('Available')
     end
 
-    it 'ignores invalid values' do
+    it 'does not allow setting an invalid value' do
       expect {
         subject.value = 'Invalid'
-      }.not_to raise_error
-
-      expect(subject.value).to be_nil
+      }.to raise_error(ArgumentError)
     end
 
     it 'allows setting by numeric value' do
@@ -87,12 +85,10 @@ describe OData4::EnumType, vcr: {cassette_name: 'enum_type_specs'} do
         expect(subject.value).to eq(%w[Available Backordered])
       end
 
-      it 'allows setting an invalid value' do
+      it 'does not allow setting invalid values' do
         expect {
           subject.value = 'Available, Invalid'
-        }.not_to raise_error
-
-        expect(subject.value).to eq(['Available'])
+        }.to raise_error(ArgumentError)
       end
 
       it 'allows setting by numeric value' do
@@ -104,29 +100,31 @@ describe OData4::EnumType, vcr: {cassette_name: 'enum_type_specs'} do
     end
   end
 
-  describe 'strict mode' do
-    let(:subject) { enum_type.property_class.new('ProductStatus', nil, strict: true) }
-
-    describe '#strict?' do
-      it { expect(subject).to be_strict }
+  describe 'lenient validation' do
+    let(:subject) do
+      enum_type.property_class.new('ProductStatus', nil, strict: false)
     end
 
     describe '#value=' do
-      it 'does not allow setting an invalid value' do
+      it 'ignores invalid values' do
         expect {
           subject.value = 'Invalid'
-        }.to raise_error(ArgumentError)
+        }.not_to raise_error
+
+        expect(subject.value).to be_nil
       end
 
-      context 'when is_flags=true' do
+      context 'when `IsFlags` is true' do
         before do
           subject.define_singleton_method(:is_flags?) { true }
         end
 
-        it 'does not allow setting invalid values' do
+        it 'ignores invalid values' do
           expect {
             subject.value = 'Available, Invalid'
-          }.to raise_error(ArgumentError)
+          }.not_to raise_error
+
+          expect(subject.value).to eq(['Available'])
         end
       end
     end

--- a/spec/odata4/properties/decimal_spec.rb
+++ b/spec/odata4/properties/decimal_spec.rb
@@ -12,13 +12,40 @@ describe OData4::Properties::Decimal do
   it { expect { subject.value = BigDecimal((-7.9 * (10**28)), 2) - 1 }.to raise_error(ArgumentError) }
   it { expect { subject.value = BigDecimal((3.4 * (10**-28)), 2) * 3.14151 + 5 }.to raise_error(ArgumentError) }
 
-  it { expect(lambda {
-    subject.value = '19.89043256'
-    subject.value
-  }.call).to eq(BigDecimal('19.89043256')) }
+  describe '#value=' do
+    it 'allows BigDecimal to be set' do
+      subject.value = BigDecimal('19.89043256')
+      expect(subject.value).to eq(BigDecimal('19.89043256'))
+    end
 
-  it { expect(lambda {
-    subject.value = BigDecimal('19.89043256')
-    subject.value
-  }.call).to eq(BigDecimal('19.89043256')) }
+    it 'allows string value to be set' do
+      subject.value = '19.89043256'
+      expect(subject.value).to eq(BigDecimal('19.89043256'))
+    end
+
+    it 'ignores invalid characters' do
+      subject.value = '123.4-foobar-5'
+      expect(subject.value).to eq(BigDecimal('123.4'))
+    end
+
+    it 'inteprets anything that is not a number as 0' do
+      subject.value = 'foobar'
+      expect(subject.value).to eq(BigDecimal(0))
+    end
+
+    it 'does not allow values outside a certain range' do
+      expect { subject.value = 'Infinity' }.to raise_error(ArgumentError)
+    end
+
+    describe 'lenient validation' do
+      let(:subject) do
+        OData4::Properties::Decimal.new('Decimal', '678.90325', strict: false)
+      end
+
+      it 'ignores invalid values' do
+        subject.value = 'Infinity'
+        expect(subject.value).to eq(BigDecimal('Infinity'))
+      end
+    end
+  end
 end

--- a/spec/odata4/properties/decimal_spec.rb
+++ b/spec/odata4/properties/decimal_spec.rb
@@ -6,7 +6,7 @@ describe OData4::Properties::Decimal do
   it { expect(subject.type).to eq('Edm.Decimal') }
   it { expect(subject.value).to eq(BigDecimal('678.90325')) }
 
-  it { expect(subject.url_value).to eq('678.90325M') }
+  it { expect(subject.url_value).to eq('678.90325') }
 
   it { expect { subject.value = BigDecimal((7.9 * (10**28)), 2) + 1 }.to raise_error(ArgumentError) }
   it { expect { subject.value = BigDecimal((-7.9 * (10**28)), 2) - 1 }.to raise_error(ArgumentError) }

--- a/spec/odata4/property_spec.rb
+++ b/spec/odata4/property_spec.rb
@@ -1,32 +1,71 @@
 require 'spec_helper'
 
 describe OData4::Property do
+  let(:service) do
+    OData4::Service.open('http://services.odata.org/V4/OData/OData.svc', metadata_file: metadata_file)
+  end
+  let(:metadata_file) { 'spec/fixtures/files/metadata.xml' }
   let(:subject) { OData4::Property.new('PropertyName', '1') }
   let(:good_comparison) { OData4::Property.new('GoodComparison', '1') }
   let(:bad_comparison) { OData4::Property.new('BadComparison', '2') }
 
-  it { expect(subject).to respond_to(:name) }
-  it { expect(subject.name).to eq('PropertyName') }
+  describe '#name' do
+    it { expect(subject).to respond_to(:name) }
+    it { expect(subject.name).to eq('PropertyName') }
+  end
 
-  it { expect(subject).to respond_to(:value) }
-  it { expect(subject.value).to eq('1') }
+  describe '#value' do
+    it { expect(subject).to respond_to(:value) }
+    it { expect(subject.value).to eq('1') }
+  end
 
-  it { expect(subject).to respond_to(:xml_value) }
-  it { expect(subject.xml_value).to eq('1') }
+  describe '#xml_value' do
+    it { expect(subject).to respond_to(:xml_value) }
+    it { expect(subject.xml_value).to eq('1') }
+  end
 
-  it { expect(subject).to respond_to(:url_value) }
-  it { expect(subject.url_value).to eq('1') }
+  describe '#url_value' do
+    it { expect(subject).to respond_to(:url_value) }
+    it { expect(subject.url_value).to eq('1') }
+  end
 
-  it { expect(subject).to respond_to(:type) }
-  it { expect(lambda {subject.type}).to raise_error(NotImplementedError) }
+  describe '#type' do
+    it { expect(subject).to respond_to(:type) }
+    it { expect(lambda {subject.type}).to raise_error(NotImplementedError) }
+  end
 
-  it { expect(subject).to respond_to(:allows_nil?) }
-  it { expect(subject.allows_nil?).to eq(true) }
+  describe '#allows_nil?' do
+    it { expect(subject).to respond_to(:allows_nil?) }
+    it { expect(subject.allows_nil?).to eq(true) }
+  end
 
-  it { expect(subject).to respond_to(:concurrency_mode) }
-  it { expect(subject.concurrency_mode).to eq(:none) }
+  describe '#strict?' do
+    it { expect(subject).to respond_to(:strict?) }
 
-  it { expect(subject).to respond_to(:==) }
-  it { expect(subject == good_comparison).to eq(true) }
-  it { expect(subject == bad_comparison).to eq(false) }
+    it 'defaults to true' do
+      expect(subject.strict?).to eq(true)
+    end
+
+    it 'can be switched off via constructor option' do
+      subject = OData4::Property.new('PropertyName', '1', strict: false)
+      expect(subject.strict?).to eq(false)
+    end
+
+    it 'can be switched off via service level option' do
+      service.options[:strict] = false
+      subject = OData4::Property.new('PropertyName', '1', service: service)
+      expect(subject.strict?).to eq(false)
+    end
+  end
+
+  describe '#concurrency_mode' do
+    it { expect(subject).to respond_to(:concurrency_mode) }
+    it { expect(subject.concurrency_mode).to eq(:none) }
+  end
+
+  describe '#==' do
+    it { expect(subject).to respond_to(:==) }
+    it { expect(subject == good_comparison).to eq(true) }
+    it { expect(subject == bad_comparison).to eq(false) }
+  end
 end


### PR DESCRIPTION
## Description

This implements lenient property validation, which is optional. Adds a new service creation option `strict`, which defaults to `true`. When set to false, any errors during property validation, instead of raising an exception, will simply log a warning instead.

Implements #3.