### PR TITLE
Adding basic Collection property type

### DIFF
--- a/lib/odata4/entity.rb
+++ b/lib/odata4/entity.rb
@@ -236,13 +236,21 @@ module OData4
     private
 
     def instantiate_property(property_name, value_xml)
-      value_type = schema.get_property_type(name, property_name)
-      klass = ::OData4::PropertyRegistry[value_type]
+      prop_type = schema.get_property_type(name, property_name)
+      prop_type, value_type = prop_type.split(/\(|\)/)
+
+      if prop_type == 'Collection'
+        klass = ::OData4::Properties::Collection
+        options = { value_type: value_type }
+      else
+        klass = ::OData4::PropertyRegistry[prop_type]
+        options = {}
+      end
 
       if klass.nil?
-        raise RuntimeError, "Unknown property type: #{value_type}"
+        raise RuntimeError, "Unknown property type: #{prop_type}"
       else
-        klass.from_xml(value_xml, service: service)
+        klass.from_xml(value_xml, options.merge(service: service))
       end
     end
 

--- a/lib/odata4/properties.rb
+++ b/lib/odata4/properties.rb
@@ -4,6 +4,7 @@ require 'odata4/properties/number'
 # Implementations
 require 'odata4/properties/binary'
 require 'odata4/properties/boolean'
+require 'odata4/properties/collection'
 require 'odata4/properties/date'
 require 'odata4/properties/date_time'
 require 'odata4/properties/date_time_offset'

--- a/lib/odata4/properties/collection.rb
+++ b/lib/odata4/properties/collection.rb
@@ -1,0 +1,50 @@
+module OData4
+  module Properties
+    # Defines the Collection OData4 type.
+    class Collection < OData4::Property
+      # Overriding default constructor to avoid converting
+      # value to string.
+      # TODO: Make this the default for all property types?
+      def initialize(name, value, options = {})
+        super(name, value, options)
+        self.value = value
+      end
+
+      def value
+        if @value.nil?
+          nil
+        else
+          @value.map(&:value)
+        end
+      end
+
+      def value=(value)
+        if value.nil? && allows_nil?
+          @value = nil
+        elsif value.respond_to?(:map)
+          @value = value.map.with_index do |element, index|
+            type_class.new("#{name}[#{index}]", element)
+          end
+        else
+          validation_error 'Value must be an array'
+        end
+      end
+
+      def url_value
+        '[' + @value.map(&:url_value).join(',') + ']'
+      end
+
+      def type
+        "Collection(#{value_type})"
+      end
+
+      def value_type
+        options[:value_type] || 'Edm.String'
+      end
+
+      def type_class
+        OData4::PropertyRegistry[value_type]
+      end
+    end
+  end
+end

--- a/lib/odata4/schema.rb
+++ b/lib/odata4/schema.rb
@@ -128,10 +128,16 @@ module OData4
 
     def process_property_from_xml(property_xml)
       property_name = property_xml.attributes['Name'].value
-      value_type = property_xml.attributes['Type'].value
+      property_type = property_xml.attributes['Type'].value
       property_options = { service: service }
 
-      klass = ::OData4::PropertyRegistry[value_type]
+      property_type, value_type = property_type.split(/\(|\)/)
+      if property_type == 'Collection'
+        klass = ::OData4::Properties::Collection
+        property_options.merge(value_type: value_type)
+      else
+        klass = ::OData4::PropertyRegistry[property_type]
+      end
 
       if klass.nil?
         raise RuntimeError, "Unknown property type: #{value_type}"

--- a/spec/odata4/properties/collection_spec.rb
+++ b/spec/odata4/properties/collection_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe OData4::Properties::Collection do
+  let(:subject) { OData4::Properties::Collection.new('Names', names) }
+  let(:names) { %w[Dan Greg Jon] }
+  let(:new_names) { %w[Andrew Doug Paul] }
+
+  it { expect(subject.type).to eq('Collection(Edm.String)') }
+  it { expect(subject.value).to eq(['Dan', 'Greg', 'Jon']) }
+  it { expect(subject.url_value).to eq("['Dan','Greg','Jon']") }
+
+  describe '#value=' do
+    it 'allows an array of string values to be set' do
+      subject.value = new_names
+      expect(subject.value).to eq(new_names)
+    end
+  end
+
+  # TODO: Make collection type work properly with data types other than string
+  xcontext 'with value type other than Edm.String' do
+    let(:subject) { OData4::Properties::Collection.new('Bits', [1, 0, 1], value_type: 'Edm.Binary') }
+
+    it { expect(subject.type).to eq('Collection(Edm.Int32)') }
+    it { expect(subject.value).to eq([1, 0, 1]) }
+    it { expect(subject.url_value).to eq('[1,0,1]') }
+
+    it 'does not allow other property types to be set' do
+      expect {
+        subject.value = names
+      }.to raise_error(ArgumentError)
+    end
+
+    xdescribe 'lenient validation' do
+      let(:subject) do
+        OData4::Properties::Collection.new('Names', names, value_type: 'Edm.String', strict: false)
+      end
+
+      it 'ignores invalid values' do
+        subject.value = [1, 2, 3]
+        expect(subject.value).to eq([])
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a very basic implementation of a `Collection` property type with an arbitrary value type. A collection is basically an array of properties of a specific primitive (or complex) base type. 

Currently only tested with `Edm.String` as a value type, as that's the only thing we need for now.

This resolves #11.